### PR TITLE
chore: ensure EOL compatablity for unix and windows systems

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     'react',
   ],
   rules: {
+    'linebreak-style': ['error', process.platform === 'win32' ? 'windows' : 'unix'],
   },
 };


### PR DESCRIPTION
For team members that use Windows machines, you may have encounted the following error:
`Expected linebreaks to be 'LF' but found 'CRLF'
`

_"CRLF stands for Carriage Return Line Feed, and LF stands for Line Feed. CRLF is a two-character sequence used to indicate the end of a line of text in a file. It is represented by the characters CR (carriage return) and LF (line feed). CRLF is used in Windows-based systems, while LF is used in Unix-based systems."_

Added a rule in the linter configuration to account for this.
Based on the operating system, it will take appropriate line endings.