### PR TITLE
CRLF fix on server side

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
     ecmaVersion: 'latest',
   },
   rules: {
+    'linebreak-style': ['error', process.platform === 'win32' ? 'windows' : 'unix'],
   },
 };


### PR DESCRIPTION
`error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style`
Encounter same error for line breaks on server side, deploy same fix as client side

Reference: [https://github.com/d-x-s/airon-fitness/pull/9](url)