### PR TITLE
E2E JWT Auth (Register, Login, Logout) + Toast Context + Responsive Signup Styling

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4130,95 +4130,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
-      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.16.5",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
@@ -17114,19 +17025,6 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/typewriter-effect": {

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:3001",
   "dependencies": {
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,21 +1,14 @@
 import {
   CssBaseline,
 } from '@mui/material';
-import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
-import { Outlet, useNavigate } from 'react-router-dom';
+import React from 'react';
+import { Outlet } from 'react-router-dom';
 
+import useNoUserRedirect from './components/common/hooks/useNoUserRedirect';
 import ResponsiveAppBar from './components/Navbar';
 
 export default function App() {
-  const {
-    user,
-  } = useSelector((state) => state.auth);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!user) navigate('/login');
-  }, [user]);
+  useNoUserRedirect('/login');
 
   return (
     <>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,11 +8,16 @@ import Toast from './components/common/context/Toast';
 import ResponsiveAppBar from './components/Navbar';
 import theme from './theme';
 
-const noAppBarRoutes = ['lib', 'signup'];
+const noAppBarRoutes = ['lib', 'signup', 'login'];
 
 export default function App() {
   const location = window.location.href.split('/');
-  const showAppBar = !noAppBarRoutes.includes(location[location.length - 1]);
+  const showAppBar = noAppBarRoutes
+    .reduce(
+      (prevVal, currVal) => !location[location.length - 1]
+        .startsWith(currVal) && prevVal,
+      true,
+    );
 
   return (
     <Toast>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,12 +1,22 @@
 import {
   CssBaseline,
 } from '@mui/material';
-import React from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 import ResponsiveAppBar from './components/Navbar';
 
 export default function App() {
+  const {
+    user,
+  } = useSelector((state) => state.auth);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) navigate('/login');
+  }, [user]);
+
   return (
     <>
       <CssBaseline />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,31 +1,17 @@
 import {
-  CssBaseline, ThemeProvider,
+  CssBaseline,
 } from '@mui/material';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
-import Toast from './components/common/context/Toast';
 import ResponsiveAppBar from './components/Navbar';
-import theme from './theme';
-
-const noAppBarRoutes = ['lib', 'signup', 'login'];
 
 export default function App() {
-  const location = window.location.href.split('/');
-  const showAppBar = noAppBarRoutes
-    .reduce(
-      (prevVal, currVal) => !location[location.length - 1]
-        .startsWith(currVal) && prevVal,
-      true,
-    );
-
   return (
-    <Toast>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        {showAppBar && <ResponsiveAppBar />}
-        <Outlet />
-      </ThemeProvider>
-    </Toast>
+    <>
+      <CssBaseline />
+      <ResponsiveAppBar />
+      <Outlet />
+    </>
   );
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,16 +4,23 @@ import {
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
+import Toast from './components/common/context/Toast';
 import ResponsiveAppBar from './components/Navbar';
 import theme from './theme';
 
+const noAppBarRoutes = ['lib', 'signup'];
+
 export default function App() {
   const location = window.location.href.split('/');
+  const showAppBar = !noAppBarRoutes.includes(location[location.length - 1]);
+
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      { location[location.length - 1] !== 'lib' && location[location.length - 1] !== 'signup' ? <ResponsiveAppBar /> : ''}
-      <Outlet />
-    </ThemeProvider>
+    <Toast>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {showAppBar && <ResponsiveAppBar />}
+        <Outlet />
+      </ThemeProvider>
+    </Toast>
   );
 }

--- a/client/src/actions/actions.js
+++ b/client/src/actions/actions.js
@@ -1,9 +1,0 @@
-export const exampleAction = (payload) => ({
-  type: 'ACTION_NAME',
-  payload,
-});
-
-export const exampleAction2 = (payload) => ({
-  type: 'ACTION_NAME2',
-  payload,
-});

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -83,7 +83,7 @@ function ResponsiveAppBar() {
               {pages.map((page) => (
                 <MenuItem key={page} onClick={handleCloseNavMenu}>
                   <Typography textAlign="center">
-                    <Link to={`/${page}`}>{page}</Link>
+                    <Link to={`/app/${page}`}>{page}</Link>
                   </Typography>
                 </MenuItem>
               ))}
@@ -115,7 +115,7 @@ function ResponsiveAppBar() {
                 onClick={handleCloseNavMenu}
                 sx={{ my: 2, color: 'white', display: 'block' }}
               >
-                <Link style={{ textDecoration: 'none', color: 'white' }} to={`/${page}`}>{page}</Link>
+                <Link style={{ textDecoration: 'none', color: 'white' }} to={`/app/${page}`}>{page}</Link>
               </Button>
             ))}
           </Box>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -8,6 +8,7 @@ import { useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 
+import { ToastContext } from './common/context/ToastContextProvider';
 import { logout, resetAuth } from '../reducers/Auth';
 
 const pages = [['home', '/app'], ['about', '/app/about'], ['profile', '/app/profile']];
@@ -15,6 +16,8 @@ const pages = [['home', '/app'], ['about', '/app/about'], ['profile', '/app/prof
 function ResponsiveAppBar() {
   const [anchorElNav, setAnchorElNav] = React.useState(null);
   const [anchorElUser, setAnchorElUser] = React.useState(null);
+  const openToast = React.useContext(ToastContext);
+
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const settings = useMemo(() => [
@@ -23,6 +26,7 @@ function ResponsiveAppBar() {
       dispatch(logout());
       dispatch(resetAuth());
       navigate('/login');
+      openToast('success', 'You have been logged out');
     }],
   ], [navigate, dispatch]);
 

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -10,7 +10,7 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { logout, resetAuth } from '../reducers/Auth';
 
-const pages = ['home', 'about', 'profile'];
+const pages = [['home', '/app'], ['about', '/app/about'], ['profile', '/app/profile']];
 
 function ResponsiveAppBar() {
   const [anchorElNav, setAnchorElNav] = React.useState(null);
@@ -94,9 +94,9 @@ function ResponsiveAppBar() {
               }}
             >
               {pages.map((page) => (
-                <MenuItem key={page} onClick={handleCloseNavMenu}>
+                <MenuItem key={page[0]} onClick={handleCloseNavMenu}>
                   <Typography textAlign="center">
-                    <Link to={`/app/${page}`}>{page}</Link>
+                    <Link to={page[1]}>{page[0]}</Link>
                   </Typography>
                 </MenuItem>
               ))}
@@ -124,11 +124,11 @@ function ResponsiveAppBar() {
           <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
             {pages.map((page) => (
               <Button
-                key={page}
+                key={page[0]}
                 onClick={handleCloseNavMenu}
                 sx={{ my: 2, color: 'white', display: 'block' }}
               >
-                <Link style={{ textDecoration: 'none', color: 'white' }} to={`/app/${page}`}>{page}</Link>
+                <Link style={{ textDecoration: 'none', color: 'white' }} to={page[1]}>{page[0]}</Link>
               </Button>
             ))}
           </Box>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -4,14 +4,27 @@ import {
   AppBar, Container, Toolbar, Typography, Box, IconButton, Menu, MenuItem, Button, Tooltip, Avatar,
 } from '@mui/material';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { logout, resetAuth } from '../reducers/Auth';
 
 const pages = ['home', 'about', 'profile'];
-const settings = ['Profile', 'Account', 'Dashboard', 'Logout'];
 
 function ResponsiveAppBar() {
   const [anchorElNav, setAnchorElNav] = React.useState(null);
   const [anchorElUser, setAnchorElUser] = React.useState(null);
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const settings = useMemo(() => [
+    ['Profile', () => navigate('/app/profile')],
+    ['Logout', () => {
+      dispatch(logout());
+      dispatch(resetAuth());
+      navigate('/login');
+    }],
+  ], [navigate, dispatch]);
 
   const handleOpenNavMenu = (event) => {
     setAnchorElNav(event.currentTarget);
@@ -143,8 +156,14 @@ function ResponsiveAppBar() {
               onClose={handleCloseUserMenu}
             >
               {settings.map((setting) => (
-                <MenuItem key={setting} onClick={handleCloseUserMenu}>
-                  <Typography textAlign="center">{setting}</Typography>
+                <MenuItem
+                  key={setting[0]}
+                  onClick={() => {
+                    setting[1]();
+                    handleCloseUserMenu();
+                  }}
+                >
+                  <Typography textAlign="center">{setting[0]}</Typography>
                 </MenuItem>
               ))}
             </Menu>

--- a/client/src/components/Profile/AdditionalProfileForm.jsx
+++ b/client/src/components/Profile/AdditionalProfileForm.jsx
@@ -2,11 +2,11 @@ import { Grid, Button } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import Form from './Forms/Form';
 import FormMultiInput from './Forms/FormMultiInput';
 import FormMultiSelect from './Forms/FormMultiSelect';
 import FormSelect from './Forms/FormSelect';
 import FormTextFieldInput from './Forms/FormTextFieldInput';
+import PaperForm from './Forms/PaperForm';
 import fetchAdditionalProfile from '../../actionCreators/AdditionalProfile';
 import {
   healthConditionsAndInjuriesOptions,
@@ -19,7 +19,7 @@ export default function AdditionalProfileForm() {
   const [healthConditionsAndInjuries, setHealthConditionsAndInjuries] = useState([]);
   const [dietaryRestrictions, setDietaryRestrictions] = useState([]);
   const [allergiesIntolerances, setAllergiesIntolerances] = useState([]);
-  const [weeklyAvailability, setWeeklyAvailability] = useState(0);
+  const [weeklyAvailability, setWeeklyAvailability] = useState('1');
   const [bodyFatPercentage, setBodyFatPercentage] = useState(0);
   const [muscleMassPercentage, setMuscleMassPercentage] = useState(0);
   const [workoutDuration, setWorkoutDuration] = useState(0);
@@ -76,7 +76,7 @@ export default function AdditionalProfileForm() {
   };
 
   return (
-    <Form
+    <PaperForm
       handleSubmit={handleSubmit}
       formTitle="Update Additional Profile"
     >
@@ -102,6 +102,7 @@ export default function AdditionalProfileForm() {
         value={healthConditionsAndInjuries}
         setValue={setHealthConditionsAndInjuries}
         options={healthConditionsAndInjuriesOptions}
+        showTitleLabel
       />
       <FormMultiSelect
         id="dietary-restrictions"
@@ -109,6 +110,7 @@ export default function AdditionalProfileForm() {
         value={dietaryRestrictions}
         setValue={setDietaryRestrictions}
         options={dietaryRestrictionsOptions}
+        showTitleLabel
       />
       <FormMultiSelect
         id="allergies-intolerances"
@@ -116,6 +118,7 @@ export default function AdditionalProfileForm() {
         value={allergiesIntolerances}
         setValue={setAllergiesIntolerances}
         options={allergiesIntolerancesOptions}
+        showTitleLabel
       />
       <FormSelect
         id="weekly-availability"
@@ -125,6 +128,7 @@ export default function AdditionalProfileForm() {
         options={weeklyAvailabilityOptions}
         half
         endAdornment="days"
+        showTitleLabel
       />
       <FormTextFieldInput
         id="workout-duration"
@@ -155,6 +159,6 @@ export default function AdditionalProfileForm() {
         </Button>
       </Grid>
       <Grid item xs={12} sm={5} />
-    </Form>
+    </PaperForm>
   );
 }

--- a/client/src/components/Profile/BasicProfileFormForm.jsx
+++ b/client/src/components/Profile/BasicProfileFormForm.jsx
@@ -6,12 +6,12 @@ import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import Form from './Forms/Form';
 import FormDatePicker from './Forms/FormDatePicker';
 import FormMultiSelect from './Forms/FormMultiSelect';
 import FormSelect from './Forms/FormSelect';
 import FormTextFieldInput from './Forms/FormTextFieldInput';
 import FormTextFieldWithRadio from './Forms/FormTextWithRadio';
+import PaperForm from './Forms/PaperForm';
 import fetchBasicProfile from '../../actionCreators/BasicProfile';
 import { genderOptions, experienceOptions, goalsOptions } from '../../constants/BasicProfile';
 import { convertInchesToCm, convertLbToKg } from '../../util';
@@ -73,7 +73,7 @@ export default function BasicProfileForm() {
   };
 
   return (
-    <Form
+    <PaperForm
       handleSubmit={handleSubmit}
       formTitle="Update Basic Profile"
     >
@@ -83,6 +83,7 @@ export default function BasicProfileForm() {
         half
         value={firstName}
         setValue={setFirstName}
+        showTitleLabel
       />
       <FormTextFieldInput
         id="last-name"
@@ -90,6 +91,7 @@ export default function BasicProfileForm() {
         half
         value={lastName}
         setValue={setLastName}
+        showTitleLabel
       />
       <FormDatePicker
         half
@@ -97,6 +99,7 @@ export default function BasicProfileForm() {
         label="Born"
         setValue={setDateOfBirth}
         value={dateOfBirth}
+        showTitleLabel
       />
       <FormSelect
         half
@@ -105,6 +108,7 @@ export default function BasicProfileForm() {
         options={genderOptions}
         setValue={setGender}
         value={gender}
+        showTitleLabel
       />
       <FormTextFieldWithRadio
         id="weight"
@@ -114,6 +118,7 @@ export default function BasicProfileForm() {
         type="number"
         radioGroups={['kg', 'lb']}
         conversionFunctions={[_.noop, convertLbToKg]}
+        showTitleLabel
       />
       <FormTextFieldWithRadio
         id="height"
@@ -123,6 +128,7 @@ export default function BasicProfileForm() {
         type="number"
         radioGroups={['cm', 'inch']}
         conversionFunctions={[_.noop, convertInchesToCm]}
+        showTitleLabel
       />
       <FormSelect
         half
@@ -131,6 +137,7 @@ export default function BasicProfileForm() {
         options={experienceOptions}
         setValue={setExperience}
         value={experience}
+        showTitleLabel
       />
       <Grid item xs={12} sm={6} />
       <FormMultiSelect
@@ -139,6 +146,7 @@ export default function BasicProfileForm() {
         value={goals}
         setValue={setGoals}
         options={goalsOptions}
+        showTitleLabel
       />
       <Grid item xs={12} sm={6} />
       <Grid item xs={12} sm={5} />
@@ -148,7 +156,7 @@ export default function BasicProfileForm() {
         </Button>
       </Grid>
       <Grid item xs={12} sm={5} />
-    </Form>
+    </PaperForm>
 
   );
 }

--- a/client/src/components/Profile/Forms/FormMultiSelect.jsx
+++ b/client/src/components/Profile/Forms/FormMultiSelect.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import CheckIcon from '@mui/icons-material/Check';
 import {
-  Autocomplete, Container, Grid, MenuItem, TextField,
+  Autocomplete, Grid, MenuItem, TextField,
 } from '@mui/material';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -18,30 +18,17 @@ export default function FormMultiSelect(props) {
     setValue,
     options,
     showTitleLabel,
-    constantWidth,
+    customTextFieldGridSize,
   } = props;
 
   return (
-    <Container sx={{
-      display: 'flex',
-      alignItems: 'center',
-    }}
-    >
-      {
-      showTitleLabel
-        ? (
-          <GridInputLabel
-            id={id}
-            label={label}
-          />
-        )
-        : ''
-    }
-      <Grid item xs={12} sm={inputGridSizing(half)}>
+    <>
+      { showTitleLabel && <GridInputLabel id={id} label={label} /> }
+      <Grid item xs={12} sm={inputGridSizing(half, customTextFieldGridSize)}>
         <Autocomplete
           value={value}
           onChange={(e, newValue) => setValue(newValue)}
-          sx={{ m: 1, width: constantWidth ? '500px' : 'fit-content' }}
+          sx={{ m: 1, width: '100%', margin: 0 }}
           multiple
           id="tags-standard"
           options={options}
@@ -68,7 +55,7 @@ export default function FormMultiSelect(props) {
           )}
         />
       </Grid>
-    </Container>
+    </>
   );
 }
 
@@ -80,11 +67,11 @@ FormMultiSelect.propTypes = {
   setValue: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTitleLabel: PropTypes.bool,
-  constantWidth: PropTypes.bool,
+  customTextFieldGridSize: PropTypes.number,
 };
 
 FormMultiSelect.defaultProps = {
   half: false,
   showTitleLabel: true,
-  constantWidth: false,
+  customTextFieldGridSize: 0,
 };

--- a/client/src/components/Profile/Forms/FormSelect.jsx
+++ b/client/src/components/Profile/Forms/FormSelect.jsx
@@ -1,6 +1,5 @@
 import {
   Grid, InputLabel, FormControl, Select, MenuItem, InputAdornment,
-  Container,
 } from '@mui/material';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -18,27 +17,14 @@ export default function FormSelect(props) {
     setValue,
     options,
     endAdornment,
-    limitWidth,
-    flexbox,
+    customTextFieldGridSize,
   } = props;
 
   return (
-    <Container sx={flexbox ? {
-      display: 'flex',
-      alignItems: 'center',
-    } : { display: 'contents' }}
-    >
-      {
-          showTitleLabel
-            ? (
-              <GridInputLabel
-                id={id}
-                label={label}
-              />
-            ) : ''
-        }
-      <Grid item xs={12} sm={inputGridSizing(half)}>
-        <FormControl fullWidth size={limitWidth ? '' : 'small'} sx={limitWidth ? { m: 1, width: 500 } : {}}>
+    <>
+      { showTitleLabel && <GridInputLabel id={id} label={label} /> }
+      <Grid item xs={12} sm={inputGridSizing(half, customTextFieldGridSize)}>
+        <FormControl fullWidth size="small">
           <InputLabel
             id={`${id}-label`}
             sx={{
@@ -71,7 +57,7 @@ export default function FormSelect(props) {
           </Select>
         </FormControl>
       </Grid>
-    </Container>
+    </>
   );
 }
 
@@ -83,15 +69,13 @@ FormSelect.propTypes = {
   value: PropTypes.string.isRequired,
   setValue: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
-  limitWidth: PropTypes.bool,
-  flexbox: PropTypes.bool,
   endAdornment: PropTypes.string,
+  customTextFieldGridSize: PropTypes.number,
 };
 
 FormSelect.defaultProps = {
   half: false,
   endAdornment: null,
   showTitleLabel: true,
-  limitWidth: false,
-  flexbox: false,
+  customTextFieldGridSize: 0,
 };

--- a/client/src/components/Profile/Forms/FormTextFieldInput.jsx
+++ b/client/src/components/Profile/Forms/FormTextFieldInput.jsx
@@ -18,22 +18,17 @@ export default function FormTextFieldInput(props) {
     type,
     multiline,
     endAdornment,
+    customTextFieldGridSize,
   } = props;
 
   return (
     <>
-      {
-        showTitleLabel
-          ? (
-            <Grid item xs={12} sm={2}>
-              <GridInputLabel
-                id={id}
-                label={label}
-              />
-            </Grid>
-          ) : ''
-      }
-      <Grid item xs={12} sm={inputGridSizing(half)}>
+      { showTitleLabel && <GridInputLabel id={id} label={label} /> }
+      <Grid
+        item
+        xs={12}
+        sm={inputGridSizing(half, customTextFieldGridSize)}
+      >
         <TextField
           required
           id={id}
@@ -69,6 +64,7 @@ FormTextFieldInput.propTypes = {
   setValue: PropTypes.func.isRequired,
   type: PropTypes.string,
   endAdornment: PropTypes.string,
+  customTextFieldGridSize: PropTypes.number,
 };
 
 FormTextFieldInput.defaultProps = {
@@ -77,4 +73,5 @@ FormTextFieldInput.defaultProps = {
   showTitleLabel: true,
   type: null,
   endAdornment: null,
+  customTextFieldGridSize: 0,
 };

--- a/client/src/components/Profile/Forms/FormTextWithRadio.jsx
+++ b/client/src/components/Profile/Forms/FormTextWithRadio.jsx
@@ -20,7 +20,7 @@ export default function FormTextFieldWithRadio(props) {
     // First value in array should be noop
     conversionFunctions,
     radioLabel,
-    displayFlex,
+    half,
   } = props;
   const [radioSelection, setRadioSelection] = useState(radioGroups[0]);
   const [inputValue, setInputValue] = useState(value);
@@ -55,8 +55,9 @@ export default function FormTextFieldWithRadio(props) {
         setValue={setInputValue}
         type={type}
         endAdornment={radioSelection}
+        customTextFieldGridSize={half && 3}
       />
-      <Grid item xs={displayFlex ? '' : 12} sm={displayFlex ? '' : 12}>
+      <Grid item xs={12} sm={half ? 3 : 6}>
         <FormControl>
           {radioLabel
             && <FormLabel id={`${id}-row-radio-buttons-group-label`}>{radioLabel}</FormLabel>}
@@ -95,7 +96,7 @@ FormTextFieldWithRadio.propTypes = {
   type: PropTypes.string,
   radioGroups: PropTypes.arrayOf(PropTypes.string).isRequired,
   conversionFunctions: PropTypes.arrayOf(PropTypes.func).isRequired,
-  displayFlex: PropTypes.bool,
+  half: PropTypes.bool,
 };
 
 FormTextFieldWithRadio.defaultProps = {
@@ -103,5 +104,5 @@ FormTextFieldWithRadio.defaultProps = {
   showTitleLabel: true,
   radioLabel: null,
   value: 0,
-  displayFlex: false,
+  half: false,
 };

--- a/client/src/components/Profile/Forms/PaperForm.jsx
+++ b/client/src/components/Profile/Forms/PaperForm.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-import { Typography, Grid, Container } from '@mui/material';
+import { Paper, Typography, Grid } from '@mui/material';
 import { Box } from '@mui/system';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -11,52 +11,38 @@ export const handleKeyPress = (e) => {
 };
 
 export const inputLabelSizing = 2.5;
-export const inputGridSizing = (half, custom = 0) => {
-  if (custom) return custom;
-  return half ? 3.5 : 9.5;
-};
+export const inputGridSizing = (half) => (half ? 3.5 : 9.5);
 
-export default function Form(props) {
+export default function PaperForm(props) {
   const {
     handleSubmit,
     formTitle,
     children,
-    containerSx,
-    centerTitle,
   } = props;
 
-  const centerStyle = centerTitle ? {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  } : {};
-
   return (
-    <Container sx={containerSx} maxWidth={false}>
-      <Box sx={{ padding: 5, ...centerStyle }}>
+    <Paper elevation={3} sx={{ marginRight: '15%', marginLeft: '15%' }}>
+      <Box sx={{ padding: 5 }}>
         {formTitle && <Typography variant="h6" gutterBottom sx={{ paddingBottom: 5 }}> {formTitle}</Typography>}
         <form onSubmit={handleSubmit} onKeyPress={handleKeyPress}>
-          <Grid container spacing={3}>
+          <Grid
+            container
+            spacing={3}
+          >
             {children}
           </Grid>
         </form>
       </Box>
-    </Container>
+    </Paper>
   );
 }
 
-Form.propTypes = {
+PaperForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   formTitle: PropTypes.string,
-  // eslint-disable-next-line react/forbid-prop-types
-  containerSx: PropTypes.object,
-  centerTitle: PropTypes.bool,
 };
 
-Form.defaultProps = {
+PaperForm.defaultProps = {
   formTitle: '',
-  containerSx: {},
-  centerTitle: false,
 };

--- a/client/src/components/Signup/SignupDetails.jsx
+++ b/client/src/components/Signup/SignupDetails.jsx
@@ -1,5 +1,5 @@
 import {
-  Box, Typography, Grid, TextField, Button,
+  Box, Typography, Grid, TextField, Button, Container,
 } from '@mui/material';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
@@ -64,15 +64,17 @@ export default function SignupDetails({ nextStage, setUser }) {
             />
           </Grid>
           <Grid item xs={12}>
-            <FormSelect
-              half
-              id="gender"
-              label="Gender"
-              showTitleLabel={false}
-              options={genderOptions}
-              setValue={setUserGender}
-              value={userGender}
-            />
+            <Container sx={{ display: 'contents' }}>
+              <FormSelect
+                half
+                id="gender"
+                label="Gender"
+                showTitleLabel={false}
+                options={genderOptions}
+                setValue={setUserGender}
+                value={userGender}
+              />
+            </Container>
           </Grid>
         </Grid>
         <Button

--- a/client/src/components/Signup/SignupRegisterAccount.jsx
+++ b/client/src/components/Signup/SignupRegisterAccount.jsx
@@ -122,7 +122,7 @@ export default function SignupRegisterAccount({ nextStage, setUser }) {
             </Button>
             <Grid container justifyContent="flex-end">
               <Grid item>
-                <Link href="/" variant="body2">
+                <Link href="/login" variant="body2">
                   Already have an account? Sign in
                 </Link>
               </Grid>

--- a/client/src/components/Signup/SignupRegisterAccount.jsx
+++ b/client/src/components/Signup/SignupRegisterAccount.jsx
@@ -10,23 +10,50 @@ import {
 } from '@mui/material';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { register, resetAuth } from '../../reducers/Auth';
 import { ToastContext } from '../common/context/ToastContextProvider';
+import Spinner from '../common/Spinner';
 
 export default function SignupRegisterAccount({ nextStage, setUser }) {
   const openToast = useContext(ToastContext);
+  const dispatch = useDispatch();
+  const {
+    user, isLoading, isError, isSuccess, message,
+  } = useSelector((state) => state.auth);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     const {
       email, password, confirmPassword,
     } = e.target;
 
-    if (password !== confirmPassword) openToast('error', "Password's do not match");
-
+    if (password.value !== confirmPassword.value) {
+      openToast('error', "Password's do not match");
+      return;
+    }
+    dispatch(register({ email: email.value, password: password.value }));
     setUser({ email: email.value, password: password.value });
-    nextStage(e);
   };
+
+  useEffect(() => {
+    if (isError) {
+      openToast('error', message);
+    }
+
+    if (isSuccess || user) {
+      openToast('success', 'You\'re account has been created!');
+      nextStage();
+    }
+
+    dispatch(resetAuth);
+  }, [user, isError, isSuccess, message, dispatch]);
+
+  if (isLoading) {
+    return <Spinner />;
+  }
 
   return (
     <div>

--- a/client/src/components/Signup/SignupRegisterAccount.jsx
+++ b/client/src/components/Signup/SignupRegisterAccount.jsx
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useContext } from 'react';
 
-import { ToastContext } from '../common/context/Toast';
+import { ToastContext } from '../common/context/ToastContextProvider';
 
 export default function SignupRegisterAccount({ nextStage, setUser }) {
   const openToast = useContext(ToastContext);

--- a/client/src/components/Signup/SignupRegisterAccount.jsx
+++ b/client/src/components/Signup/SignupRegisterAccount.jsx
@@ -10,10 +10,19 @@ import {
 } from '@mui/material';
 import PropTypes from 'prop-types';
 import * as React from 'react';
+import { useContext } from 'react';
 
-export default function SignupLanding({ nextStage, setUser }) {
+import { ToastContext } from '../common/context/Toast';
+
+export default function SignupRegisterAccount({ nextStage, setUser }) {
+  const openToast = useContext(ToastContext);
   const handleSubmit = (e) => {
-    const { email, username, password } = e.target;
+    e.preventDefault();
+    const {
+      email, username, password, confirmPassword,
+    } = e.target;
+
+    if (password !== confirmPassword) openToast('error', "Password's do not match");
 
     setUser({ email: email.value, username: username.value, password: password.value });
     nextStage(e);
@@ -59,7 +68,7 @@ export default function SignupLanding({ nextStage, setUser }) {
                   fullWidth
                   id="username"
                   label="Username"
-                  name="username"
+                  name="peepoo"
                 />
               </Grid>
               <Grid item xs={12}>
@@ -77,7 +86,7 @@ export default function SignupLanding({ nextStage, setUser }) {
                 <TextField
                   required
                   fullWidth
-                  name="confirm-password"
+                  name="confirmPassword"
                   label="Confirm Password"
                   type="password"
                   id="confirm-password"
@@ -107,7 +116,7 @@ export default function SignupLanding({ nextStage, setUser }) {
   );
 }
 
-SignupLanding.propTypes = {
+SignupRegisterAccount.propTypes = {
   nextStage: PropTypes.func.isRequired,
   setUser: PropTypes.func.isRequired,
 };

--- a/client/src/components/Signup/SignupStats.jsx
+++ b/client/src/components/Signup/SignupStats.jsx
@@ -4,6 +4,7 @@ import {
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import {
   healthConditionsAndInjuriesOptions, dietaryRestrictionsOptions,
@@ -24,12 +25,14 @@ export default function SignupStats({ setUser, nextStage }) {
   const [dietaryRestrictions, setDietaryRestrictions] = useState([]);
   const [allergiesIntolerances, setAllergiesIntolerances] = useState([]);
   const [weeklyAvailability, setWeeklyAvailability] = useState('1');
+  const navigate = useNavigate();
 
   const handleSubmit = (e) => {
     setUser((prevState) => ({
       ...prevState, weight, height, experience,
     }));
     nextStage(e);
+    navigate('/app');
   };
 
   return (

--- a/client/src/components/Signup/SignupStats.jsx
+++ b/client/src/components/Signup/SignupStats.jsx
@@ -1,6 +1,7 @@
 import {
-  Box, Typography, Grid, Button,
+  Grid, Button,
 } from '@mui/material';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 
@@ -9,30 +10,11 @@ import {
   allergiesIntolerancesOptions, weeklyAvailabilityOptions,
 } from '../../constants/AdditionalProfile';
 import { experienceOptions } from '../../constants/BasicProfile';
+import { convertInchesToCm, convertLbToKg } from '../../util';
+import Form from '../Profile/Forms/Form';
 import FormMultiSelect from '../Profile/Forms/FormMultiSelect';
 import FormSelect from '../Profile/Forms/FormSelect';
 import FormTextFieldWithRadio from '../Profile/Forms/FormTextWithRadio';
-
-const classes = {
-  root: {
-    flexGrow: 1,
-    margin: '2px',
-    width: '80%',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-  },
-  gridItem: {
-    padding: '2px',
-  },
-  selectForm: {
-    marginTop: '12px',
-    marginLeft: '12px',
-  },
-  toggleForm: {
-    marginTop: '12px',
-  },
-};
 
 export default function SignupStats({ setUser, nextStage }) {
   const [weight, setWeight] = useState(0);
@@ -41,7 +23,7 @@ export default function SignupStats({ setUser, nextStage }) {
   const [healthConditionsAndInjuries, setHealthConditionsAndInjuries] = useState([]);
   const [dietaryRestrictions, setDietaryRestrictions] = useState([]);
   const [allergiesIntolerances, setAllergiesIntolerances] = useState([]);
-  const [weeklyAvailability, setWeeklyAvailability] = useState([]);
+  const [weeklyAvailability, setWeeklyAvailability] = useState('1');
 
   const handleSubmit = (e) => {
     setUser((prevState) => ({
@@ -51,111 +33,101 @@ export default function SignupStats({ setUser, nextStage }) {
   };
 
   return (
-    <Box
-      sx={{
-        marginTop: 8,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-      }}
+    <Form
+      handleSubmit={handleSubmit}
+      formTitle="Lastly, we will need some background information"
+      containerSx={{ width: '80vw', maxWidth: '675px' }}
+      centerTitle
     >
-      <Typography component="h1" variant="h5">
-        Lastly, we will need some background information
-      </Typography>
-      <Box component="form" noValidate onSubmit={handleSubmit} sx={classes.root}>
-        <Grid container spacing={2} sx={classes.toggleForm}>
-          <Grid container item spacing={1} sx={{ display: 'flex', justifyContent: 'center' }}>
-            <FormTextFieldWithRadio
-              id="weight"
-              label="Weight"
-              showTitleLabel={false}
-              value={weight}
-              setValue={setWeight}
-              type="number"
-              radioGroups={['lb', 'kg']}
-              displayFlex
-            />
-            <FormTextFieldWithRadio
-              id="height"
-              label="Height"
-              showTitleLabel={false}
-              value={height}
-              setValue={setHeight}
-              type="number"
-              radioGroups={['cm', 'in']}
-              displayFlex
-            />
-          </Grid>
-          <Grid container spacing={2} sx={classes.selectForm}>
-            <Grid item sm={12} lg={6} xl={4}>
-              <FormSelect
-                id="experience"
-                label="Experience"
-                showTitleLabel={false}
-                options={experienceOptions}
-                setValue={setExperience}
-                value={experience}
-                limitWidth
-                flexbox
-              />
-            </Grid>
-            <Grid item sm={12} md={8} lg={6} xl={4}>
-              <FormMultiSelect
-                id="health-conditions-and-injuries"
-                label="Health Conditions & Injuries"
-                value={healthConditionsAndInjuries}
-                setValue={setHealthConditionsAndInjuries}
-                options={healthConditionsAndInjuriesOptions}
-                showTitleLabel={false}
-                constantWidth
-              />
-            </Grid>
-            <Grid item sm={12} md={8} lg={6} xl={4}>
-              <FormMultiSelect
-                id="allergies-intolerances"
-                label="Allergies & Intolerances"
-                value={allergiesIntolerances}
-                setValue={setAllergiesIntolerances}
-                options={allergiesIntolerancesOptions}
-                showTitleLabel={false}
-                constantWidth
-              />
-            </Grid>
-            <Grid item sm={12} md={8} lg={6} xl={4}>
-              <FormSelect
-                id="weekly-availability"
-                label="Weekly Availability"
-                value={weeklyAvailability}
-                setValue={setWeeklyAvailability}
-                options={weeklyAvailabilityOptions}
-                showTitleLabel={false}
-                limitWidth
-                flexbox
-                endAdornment="days"
-              />
-            </Grid>
-            <Grid item sm={12} md={8} lg={6} xl={4}>
-              <FormMultiSelect
-                id="dietary-restrictions"
-                label="Dietary Restrictions"
-                value={dietaryRestrictions}
-                setValue={setDietaryRestrictions}
-                options={dietaryRestrictionsOptions}
-                showTitleLabel={false}
-                constantWidth
-              />
-            </Grid>
-          </Grid>
-        </Grid>
+      <FormTextFieldWithRadio
+        id="weight"
+        label="Weight"
+        showTitleLabel={false}
+        value={weight}
+        setValue={setWeight}
+        type="number"
+        radioGroups={['lb', 'kg']}
+        conversionFunctions={[_.noop, convertLbToKg]}
+        half
+      />
+      <FormTextFieldWithRadio
+        id="height"
+        label="Height"
+        showTitleLabel={false}
+        value={height}
+        setValue={setHeight}
+        type="number"
+        radioGroups={['cm', 'in']}
+        conversionFunctions={[_.noop, convertInchesToCm]}
+        half
+      />
+      <FormSelect
+        id="experience"
+        label="Experience"
+        value={experience}
+        setValue={setExperience}
+        options={experienceOptions}
+        showTitleLabel={false}
+        customTextFieldGridSize={6}
+      />
+      <FormSelect
+        id="weekly-availability"
+        label="Weekly Availability"
+        value={weeklyAvailability}
+        setValue={setWeeklyAvailability}
+        options={weeklyAvailabilityOptions}
+        showTitleLabel={false}
+        endAdornment="days"
+        customTextFieldGridSize={6}
+      />
+      <FormMultiSelect
+        id="health-conditions-and-injuries"
+        label="Health Conditions & Injuries"
+        value={healthConditionsAndInjuries}
+        setValue={setHealthConditionsAndInjuries}
+        options={healthConditionsAndInjuriesOptions}
+        showTitleLabel={false}
+        customTextFieldGridSize={6}
+      />
+      <FormMultiSelect
+        id="allergies-intolerances"
+        label="Allergies & Intolerances"
+        value={allergiesIntolerances}
+        setValue={setAllergiesIntolerances}
+        options={allergiesIntolerancesOptions}
+        showTitleLabel={false}
+        customTextFieldGridSize={6}
+      />
+      <FormMultiSelect
+        id="dietary-restrictions"
+        label="Dietary Restrictions"
+        value={dietaryRestrictions}
+        setValue={setDietaryRestrictions}
+        options={dietaryRestrictionsOptions}
+        showTitleLabel={false}
+        customTextFieldGridSize={6}
+      />
+      <Grid item xs={12} sm={6} />
+      <Grid
+        item
+        xs={12}
+        sm={12}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
         <Button
           type="submit"
           variant="contained"
-          sx={{ mt: 3, mb: 2, width: '300px' }}
+          sx={{ mb: 2, width: '300px' }}
         >
           Create
         </Button>
-      </Box>
-    </Box>
+      </Grid>
+    </Form>
   );
 }
 

--- a/client/src/components/common/Spinner.jsx
+++ b/client/src/components/common/Spinner.jsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const SpinnerContainer = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 5000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const LoadingSpinner = styled.div`
+  width: 64px;
+  height: 64px;
+  border: 8px solid;
+  border-color: #000 transparent #555 transparent;
+  border-radius: 50%;
+  animation: spin 1.2s linear infinite;
+`;
+
+export default function Spinner() {
+  return (
+    <SpinnerContainer>
+      <LoadingSpinner />
+    </SpinnerContainer>
+  );
+}

--- a/client/src/components/common/context/Toast.jsx
+++ b/client/src/components/common/context/Toast.jsx
@@ -4,7 +4,7 @@ import React, { createContext, useCallback, useState } from 'react';
 
 export const ToastContext = createContext();
 
-export default function Toast(props) {
+export default function ToastContextProvider(props) {
   const {
     children,
   } = props;
@@ -34,13 +34,13 @@ export default function Toast(props) {
           {message}
         </Alert>
       </Snackbar>
-      <ToastContext.Provider value={openToast}>
+      <ToastContextProvider.Provider value={openToast}>
         {children}
-      </ToastContext.Provider>
+      </ToastContextProvider.Provider>
     </>
   );
 }
 
-Toast.propTypes = {
+ToastContextProvider.propTypes = {
   children: PropTypes.node.isRequired,
 };

--- a/client/src/components/common/context/Toast.jsx
+++ b/client/src/components/common/context/Toast.jsx
@@ -1,0 +1,46 @@
+import { Alert, Snackbar } from '@mui/material';
+import PropTypes from 'prop-types';
+import React, { createContext, useCallback, useState } from 'react';
+
+export const ToastContext = createContext();
+
+export default function Toast(props) {
+  const {
+    children,
+  } = props;
+  const [open, setOpen] = useState(false);
+  const [autoHideDuration, setautoHideDuration] = useState(6000);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState('success');
+
+  const openToast = useCallback((_severity = 'success', _message = '', _autoHideDuration = 6000) => {
+    setautoHideDuration(_autoHideDuration);
+    setSeverity(_severity);
+    setMessage(_message);
+    setOpen(true);
+  }, [autoHideDuration, severity, message, open]);
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Snackbar open={open} autoHideDuration={autoHideDuration} onClose={handleClose}>
+        <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      </Snackbar>
+      <ToastContext.Provider value={openToast}>
+        {children}
+      </ToastContext.Provider>
+    </>
+  );
+}
+
+Toast.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/client/src/components/common/context/ToastContextProvider.jsx
+++ b/client/src/components/common/context/ToastContextProvider.jsx
@@ -34,9 +34,9 @@ export default function ToastContextProvider(props) {
           {message}
         </Alert>
       </Snackbar>
-      <ToastContextProvider.Provider value={openToast}>
+      <ToastContext.Provider value={openToast}>
         {children}
-      </ToastContextProvider.Provider>
+      </ToastContext.Provider>
     </>
   );
 }

--- a/client/src/components/common/context/ToastContextProvider.jsx
+++ b/client/src/components/common/context/ToastContextProvider.jsx
@@ -14,6 +14,7 @@ export default function ToastContextProvider(props) {
   const [severity, setSeverity] = useState('success');
 
   const openToast = useCallback((_severity = 'success', _message = '', _autoHideDuration = 6000) => {
+    setOpen(false);
     setautoHideDuration(_autoHideDuration);
     setSeverity(_severity);
     setMessage(_message);

--- a/client/src/components/common/hooks/useNoUserRedirect.jsx
+++ b/client/src/components/common/hooks/useNoUserRedirect.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+// If there is no user saved in localStorage, then redirect to {path}
+export default function useNoUserRedirect(path) {
+  const {
+    user,
+  } = useSelector((state) => state.auth);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) navigate(path);
+  }, [user]);
+}

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -31,7 +31,7 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        path: 'home',
+        path: '',
         element: <Home />,
       },
       {

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,3 +1,4 @@
+import { ThemeProvider } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { configureStore } from '@reduxjs/toolkit';
@@ -9,6 +10,7 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import thunk from 'redux-thunk';
 
 import App from './App';
+import ToastContextProvider from './components/common/context/Toast';
 import About from './pages/About';
 import DesignLibrary from './pages/DesignLibrary';
 import Home from './pages/Home';
@@ -21,6 +23,7 @@ import '@fontsource/roboto/300.css';
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
+import theme from './theme';
 
 const router = createBrowserRouter([
   {
@@ -29,10 +32,6 @@ const router = createBrowserRouter([
     children: [
       {
         path: '',
-        element: <Landing />,
-      },
-      {
-        path: 'home',
         element: <Home />,
       },
       {
@@ -43,21 +42,24 @@ const router = createBrowserRouter([
         path: 'profile',
         element: <Profile />,
       },
-      {
-        path: 'signup',
-        element: <SignupFlow />,
-      },
-      {
-        path: 'login',
-        element: <Login />,
-      },
-      {
-        path: 'lib',
-        element: <DesignLibrary />,
-      },
     ],
   },
-
+  {
+    path: '/',
+    element: <Landing />,
+  },
+  {
+    path: '/login',
+    element: <Login />,
+  },
+  {
+    path: '/lib',
+    element: <DesignLibrary />,
+  },
+  {
+    path: '/signup',
+    element: <SignupFlow />,
+  },
 ]);
 
 // eslint-disable-next-line import/prefer-default-export
@@ -71,7 +73,11 @@ root.render(
   <React.StrictMode>
     <Provider store={store}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
-        <RouterProvider router={router} />
+        <ThemeProvider theme={theme}>
+          <ToastContextProvider>
+            <RouterProvider router={router} />
+          </ToastContextProvider>
+        </ThemeProvider>
       </LocalizationProvider>
     </Provider>
   </React.StrictMode>,

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -10,7 +10,7 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import thunk from 'redux-thunk';
 
 import App from './App';
-import ToastContextProvider from './components/common/context/Toast';
+import ToastContextProvider from './components/common/context/ToastContextProvider';
 import About from './pages/About';
 import DesignLibrary from './pages/DesignLibrary';
 import Home from './pages/Home';
@@ -27,11 +27,11 @@ import theme from './theme';
 
 const router = createBrowserRouter([
   {
-    path: '/',
+    path: '/app',
     element: <App />,
     children: [
       {
-        path: '',
+        path: 'home',
         element: <Home />,
       },
       {
@@ -73,11 +73,11 @@ root.render(
   <React.StrictMode>
     <Provider store={store}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
-        <ThemeProvider theme={theme}>
-          <ToastContextProvider>
+        <ToastContextProvider>
+          <ThemeProvider theme={theme}>
             <RouterProvider router={router} />
-          </ToastContextProvider>
-        </ThemeProvider>
+          </ThemeProvider>
+        </ToastContextProvider>
       </LocalizationProvider>
     </Provider>
   </React.StrictMode>,

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -13,6 +13,7 @@ import About from './pages/About';
 import DesignLibrary from './pages/DesignLibrary';
 import Home from './pages/Home';
 import Landing from './pages/Landing';
+import Login from './pages/Login';
 import Profile from './pages/Profile';
 import SignupFlow from './pages/SignupFlow';
 import rootReducer from './reducers';
@@ -45,6 +46,10 @@ const router = createBrowserRouter([
       {
         path: 'signup',
         element: <SignupFlow />,
+      },
+      {
+        path: 'login',
+        element: <Login />,
       },
       {
         path: 'lib',

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -81,7 +81,7 @@ export default function Landing() {
             designed to support individuals on their workout journey.
           </Typography>
         </div>
-        <Button variant="outlined" fontWeight="light" style={styles.actionButton}>
+        <Button variant="outlined" fontWeight="light" style={styles.actionButton} href="/login">
           Let&apos;s get started.
         </Button>
       </div>

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -26,10 +26,8 @@ export default function Login() {
       openToast('error', message);
     }
 
-    if (isSuccess || user) {
-      openToast('success', 'You\'ve been logged in');
-      navigate('/app');
-    }
+    if (isSuccess && user) openToast('success', 'You\'ve been logged in');
+    if (isSuccess || user) navigate('/app');
 
     dispatch(resetAuth);
   }, [user, isError, isSuccess, message, navigate, dispatch]);

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -36,7 +36,6 @@ export default function Login() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-
     dispatch(login({ email, password }));
   };
 

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -6,7 +6,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { ToastContext } from '../components/common/context/Toast';
+import { ToastContext } from '../components/common/context/ToastContextProvider';
 import Spinner from '../components/common/Spinner';
 import { login, resetAuth } from '../reducers/Auth';
 
@@ -28,7 +28,7 @@ export default function Login() {
 
     if (isSuccess || user) {
       openToast('success', 'You\'ve been logged in');
-      navigate('/');
+      navigate('/app/home');
     }
 
     dispatch(resetAuth);

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -28,7 +28,7 @@ export default function Login() {
 
     if (isSuccess || user) {
       openToast('success', 'You\'ve been logged in');
-      navigate('/app/home');
+      navigate('/app');
     }
 
     dispatch(resetAuth);

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,35 +1,51 @@
 import {
-  Button,
-  CssBaseline,
-  TextField,
-  Link,
-  Grid,
-  Box,
-  Typography,
-  Container,
+  Box, Button, CssBaseline, Grid, TextField, Typography,
 } from '@mui/material';
-import PropTypes from 'prop-types';
-import * as React from 'react';
-import { useContext } from 'react';
+import { Container } from '@mui/system';
+import React, { useContext, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link, useNavigate } from 'react-router-dom';
 
-import { ToastContext } from '../common/context/Toast';
+import { ToastContext } from '../components/common/context/Toast';
+import Spinner from '../components/common/Spinner';
+import { login, resetAuth } from '../reducers/Auth';
 
-export default function SignupRegisterAccount({ nextStage, setUser }) {
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const openToast = useContext(ToastContext);
-  const handleSubmit = (e) => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const {
+    user, isLoading, isError, isSuccess, message,
+  } = useSelector((state) => state.auth);
+
+  useEffect(() => {
+    if (isError) {
+      openToast('error', message);
+    }
+
+    if (isSuccess || user) {
+      openToast('success', 'You\'ve been logged in');
+      navigate('/');
+    }
+
+    dispatch(resetAuth);
+  }, [user, isError, isSuccess, message, navigate, dispatch]);
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    const {
-      email, password, confirmPassword,
-    } = e.target;
 
-    if (password !== confirmPassword) openToast('error', "Password's do not match");
-
-    setUser({ email: email.value, password: password.value });
-    nextStage(e);
+    dispatch(login({ email, password }));
   };
 
+  if (isLoading) {
+    return <Spinner />;
+  }
+
   return (
-    <div>
+    <Box>
       <Container component="main" maxWidth="xs">
         <CssBaseline />
         <Box
@@ -41,7 +57,7 @@ export default function SignupRegisterAccount({ nextStage, setUser }) {
           }}
         >
           <Typography component="h1" variant="h5">
-            Create Your Account
+            Login
           </Typography>
           <Box
             component="form"
@@ -60,6 +76,8 @@ export default function SignupRegisterAccount({ nextStage, setUser }) {
                   label="Email Address"
                   name="email"
                   autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
                 />
               </Grid>
               <Grid item xs={12}>
@@ -71,17 +89,8 @@ export default function SignupRegisterAccount({ nextStage, setUser }) {
                   type="password"
                   id="password"
                   autoComplete="new-password"
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <TextField
-                  required
-                  fullWidth
-                  name="confirmPassword"
-                  label="Confirm Password"
-                  type="password"
-                  id="confirm-password"
-                  autoComplete="new-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
                 />
               </Grid>
             </Grid>
@@ -91,23 +100,18 @@ export default function SignupRegisterAccount({ nextStage, setUser }) {
               variant="contained"
               sx={{ mt: 3, mb: 2, width: '300px' }}
             >
-              Create Account
+              Login
             </Button>
             <Grid container justifyContent="flex-end">
               <Grid item>
-                <Link href="/" variant="body2">
-                  Already have an account? Sign in
+                <Link to="/signup" variant="body2">
+                  Don&apos;t have an account? Create one.
                 </Link>
               </Grid>
             </Grid>
           </Box>
         </Box>
       </Container>
-    </div>
+    </Box>
   );
 }
-
-SignupRegisterAccount.propTypes = {
-  nextStage: PropTypes.func.isRequired,
-  setUser: PropTypes.func.isRequired,
-};

--- a/client/src/pages/SignupFlow.jsx
+++ b/client/src/pages/SignupFlow.jsx
@@ -4,7 +4,7 @@ import {
 import React, { useState } from 'react';
 
 import SignupDetails from '../components/Signup/SignupDetails';
-import SignupLanding from '../components/Signup/SignupLanding';
+import SignupRegisterAccount from '../components/Signup/SignupRegisterAccount';
 import SignupStats from '../components/Signup/SignupStats';
 
 export default function SignupFlow() {
@@ -26,7 +26,7 @@ export default function SignupFlow() {
     let stage;
     switch (step) {
       case 0:
-        stage = <SignupLanding nextStage={handleNext} setUser={setUser} />;
+        stage = <SignupRegisterAccount nextStage={handleNext} setUser={setUser} />;
         break;
       case 1:
         stage = <SignupDetails nextStage={handleNext} setUser={setUser} />;

--- a/client/src/pages/SignupFlow.jsx
+++ b/client/src/pages/SignupFlow.jsx
@@ -13,7 +13,7 @@ export default function SignupFlow() {
   const steps = ['Account Creation', 'Personal', 'Health'];
 
   const handleNext = (e) => {
-    e.preventDefault();
+    if (e) e.preventDefault();
     setStep((prevStep) => prevStep + 1);
 
     if (step === 3) {

--- a/client/src/reducers/Auth.js
+++ b/client/src/reducers/Auth.js
@@ -1,0 +1,100 @@
+/* eslint-disable no-param-reassign */
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+import authService from '../services/AuthService';
+
+// Get user from localStorage
+const user = JSON.parse(localStorage.getItem('user'));
+
+const initialState = {
+  user: user || null,
+  isError: false,
+  isSuccess: false,
+  isLoading: false,
+  message: '',
+};
+
+const getErrorMessage = (error) => (
+  error.response
+  && error.response.data
+  && error.response.data.message
+)
+  || error.message
+  || error.toString();
+
+// Register user
+export const register = createAsyncThunk(
+  'auth/register',
+  async (userData, thunkAPI) => {
+    try {
+      return await authService.register(userData);
+    } catch (error) {
+      const message = getErrorMessage(error);
+      return thunkAPI.rejectWithValue(message);
+    }
+  },
+);
+
+// Login user
+export const login = createAsyncThunk('auth/login', async (userData, thunkAPI) => {
+  try {
+    return await authService.login(userData);
+  } catch (error) {
+    const message = getErrorMessage(error);
+    return thunkAPI.rejectWithValue(message);
+  }
+});
+
+export const logout = createAsyncThunk('auth/logout', async () => {
+  await authService.logout();
+});
+
+export const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    resetAuth: (state) => {
+      state.isLoading = false;
+      state.isSuccess = false;
+      state.isError = false;
+      state.message = '';
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(register.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(register.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.isSuccess = true;
+        state.user = action.payload;
+      })
+      .addCase(register.rejected, (state, action) => {
+        state.isLoading = false;
+        state.isError = true;
+        state.message = action.payload;
+        state.user = null;
+      })
+      .addCase(login.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(login.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.isSuccess = true;
+        state.user = action.payload;
+      })
+      .addCase(login.rejected, (state, action) => {
+        state.isLoading = false;
+        state.isError = true;
+        state.message = action.payload;
+        state.user = null;
+      })
+      .addCase(logout.fulfilled, (state) => {
+        state.user = null;
+      });
+  },
+});
+
+export const { resetAuth } = authSlice.actions;
+export default authSlice.reducer;

--- a/client/src/reducers/Auth.js
+++ b/client/src/reducers/Auth.js
@@ -27,7 +27,7 @@ export const register = createAsyncThunk(
   'auth/register',
   async (userData, thunkAPI) => {
     try {
-      return await authService.register(userData);
+      return await authService.registerUser(userData);
     } catch (error) {
       const message = getErrorMessage(error);
       return thunkAPI.rejectWithValue(message);
@@ -38,7 +38,7 @@ export const register = createAsyncThunk(
 // Login user
 export const login = createAsyncThunk('auth/login', async (userData, thunkAPI) => {
   try {
-    return await authService.login(userData);
+    return await authService.loginUser(userData);
   } catch (error) {
     const message = getErrorMessage(error);
     return thunkAPI.rejectWithValue(message);
@@ -46,7 +46,7 @@ export const login = createAsyncThunk('auth/login', async (userData, thunkAPI) =
 });
 
 export const logout = createAsyncThunk('auth/logout', async () => {
-  await authService.logout();
+  await authService.logoutUser();
 });
 
 export const authSlice = createSlice({

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 
 import additionalProfileReducer from './AdditionalProfile';
+import authReducer from './Auth';
 import basicProfileReducer from './BasicProfile';
 import fitnessPlanReducer from './FitnessPlan';
 
@@ -8,6 +9,7 @@ const rootReducer = combineReducers({
   basicProfile: basicProfileReducer,
   additionalProfile: additionalProfileReducer,
   fitnessPlan: fitnessPlanReducer,
+  auth: authReducer,
 });
 
 export default rootReducer;

--- a/client/src/services/AuthService.js
+++ b/client/src/services/AuthService.js
@@ -1,0 +1,37 @@
+import axios from 'axios';
+
+/** Backend + local storage calls */
+
+const API_URL = '/userInfo/';
+
+const registerUser = async (userData) => {
+  const response = await axios.post(API_URL, userData);
+
+  if (response.data) {
+    localStorage.setItem('user', JSON.stringify(response.data));
+  }
+
+  return response.data;
+};
+
+const loginUser = async (userData) => {
+  const response = await axios.post(`${API_URL}login`, userData);
+
+  if (response.data) {
+    localStorage.setItem('user', JSON.stringify(response.data));
+  }
+
+  return response.data;
+};
+
+const logoutUser = () => {
+  localStorage.removeItem('user');
+};
+
+const authService = {
+  registerUser,
+  logoutUser,
+  loginUser,
+};
+
+export default authService;

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   },
   rules: {
     'prefer-destructuring': 'off',
+    'no-underscore-dangle': 'off',
     'linebreak-style': ['error', process.platform === 'win32' ? 'windows' : 'unix'],
   },
 };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,19 +25,6 @@
         "nodemon": "^2.0.22"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
-      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.11"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -331,16 +318,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/aria-query": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.2.1.tgz",
-      "integrity": "sha512-7uFg4b+lETFgdaJyETnILsXgnnzVnkHcgRbwbPwevm5x/LmUlt3MjczMRe1zg824iBgXZNRPTBftNYyRSKLp2g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
@@ -414,27 +391,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.tosorted": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
-      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.1.3"
-      }
-    },
-    "node_modules/ast-types-flow": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -445,26 +401,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/axobject-query": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
       }
     },
     "node_modules/balanced-match": {
@@ -726,13 +662,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/damerau-levenshtein": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
-      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -769,16 +698,6 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -825,13 +744,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -1170,131 +1082,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
-      "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "aria-query": "^5.1.3",
-        "array-includes": "^3.1.6",
-        "array.prototype.flatmap": "^1.3.1",
-        "ast-types-flow": "^0.0.7",
-        "axe-core": "^4.6.2",
-        "axobject-query": "^3.1.1",
-        "damerau-levenshtein": "^1.0.8",
-        "emoji-regex": "^9.2.2",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^3.3.3",
-        "language-tags": "=1.0.5",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.6",
-        "object.fromentries": "^2.0.6",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.32.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz",
-      "integrity": "sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flatmap": "^1.3.1",
-        "array.prototype.tosorted": "^1.1.1",
-        "doctrine": "^2.1.0",
-        "estraverse": "^5.3.0",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.6",
-        "object.fromentries": "^2.0.6",
-        "object.hasown": "^1.1.2",
-        "object.values": "^1.1.6",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.4",
-        "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2205,13 +1992,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2282,20 +2062,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jsx-ast-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
-      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "array-includes": "^3.1.5",
-        "object.assign": "^4.1.3"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -2321,23 +2087,6 @@
       "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/language-subtag-registry": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
-      "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/language-tags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "language-subtag-registry": "~0.3.2"
       }
     },
     "node_modules/levn": {
@@ -2378,19 +2127,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2731,38 +2467,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/object.fromentries": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
-      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.hasown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
@@ -2926,18 +2630,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3020,13 +2712,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3038,13 +2723,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
@@ -3340,26 +3018,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/string.prototype.matchall": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
-      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.3",
-        "side-channel": "^1.0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trim": {

--- a/server/src/controllers/userInfoController.js
+++ b/server/src/controllers/userInfoController.js
@@ -12,7 +12,7 @@ const registerUser = asyncHandler(async (req, res) => {
     password, email,
   } = req.body;
   if (!email || !password) {
-    res.status(400);
+    res.status(400).json({ message: 'Please include an email and password' });
     throw new Error('Please include an email and password');
   }
 
@@ -20,7 +20,7 @@ const registerUser = asyncHandler(async (req, res) => {
   const userExists = await UserInfo.findOne({ email });
 
   if (userExists) {
-    res.status(400);
+    res.status(400).json({ message: 'User already exists' });
     throw new Error('User already exists');
   }
 
@@ -42,7 +42,7 @@ const registerUser = asyncHandler(async (req, res) => {
     });
   }
 
-  res.status(400);
+  res.status(400).json({ message: 'invalid user data' });
   throw new Error('invalid user data');
 });
 
@@ -64,7 +64,7 @@ const loginUser = asyncHandler(async (req, res) => {
       token: generateToken(user._id),
     });
   } else {
-    res.status(400);
+    res.status(400).json({ message: 'Invalid credentials' });
     throw new Error('Invalid credentials');
   }
 });

--- a/server/src/controllers/workoutScheduleController.js
+++ b/server/src/controllers/workoutScheduleController.js
@@ -42,7 +42,7 @@ const updateUserWorkoutScheduleByUserID = (req, res) => {
 
   if (foundItemIndex < 0) return res.status(404).send({ message: 'Item not found' });
   if (!req.body.schedule) {
-    return res.status(400).send({ message: 'Missing paylod' });
+    return res.status(400).send({ message: 'Missing payload' });
   }
   schedules[foundItemIndex].schedule = req.body.schedule;
   return res.send(schedules[foundItemIndex]);

--- a/server/src/middleware/authMiddleware.js
+++ b/server/src/middleware/authMiddleware.js
@@ -1,7 +1,6 @@
 const jwt = require('jsonwebtoken');
 const asyncHandler = require('express-async-handler');
-const { users: UserInfo } = require('../controllers/userInfoController');
-// const UserInfo = require('../models/userInfoModel')
+const UserInfo = require('../models/UserInfoModel');
 
 // ref: https://www.youtube.com/watch?v=enopDSs3DRw
 const protect = asyncHandler(async (req, res, next) => {
@@ -19,8 +18,7 @@ const protect = asyncHandler(async (req, res, next) => {
       const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
       // Get user from the token
-      // req.user = await User.findById(decoded.id).select('-password');
-      req.user = UserInfo.find((user) => user.userID === decoded.userID);
+      req.user = await UserInfo.findById(decoded._id).select('-password');
       next();
     } catch (error) {
       res.status(401);

--- a/server/src/models/UserInfoModel.js
+++ b/server/src/models/UserInfoModel.js
@@ -4,6 +4,10 @@ const Schema = mongoose.Schema;
 
 const UserInfoSchema = new Schema(
   {
+    _id: {
+      type: Schema.Types.ObjectId,
+      auto: true,
+    },
     email: {
       type: String,
       required: [true, 'Please add an email'],

--- a/server/src/routes/UserInfo.js
+++ b/server/src/routes/UserInfo.js
@@ -13,22 +13,15 @@ const { protect } = require('../middleware/authMiddleware');
  * @request
  *  body:
  *    {
- *      "userID": string,
  *      "password": string,
  *      "email": string,
- *      "gptAPIKey": string,
- *      "firstName": string,
- *      "lastName": string,
- *      "profileImage": "testProfileImage"
  *    }
  *  params: n/a
  *  query params: n/a
  * @response
  *    {
- *      "userID": string,
+ *      "id": string,
  *      "email": string,
- *      "firstName": string,
- *      "lastName": string,
  *      "token": string"
  *    }
  */
@@ -48,10 +41,8 @@ router.post('/', registerUser);
  *  query params: n/a
  * @response
  *    {
- *      "userID": string,
+ *      "id": string,
  *      "email": string,
- *      "firstName": string,
- *      "lastName": string,
  *      "token": string"
  *    }
  */
@@ -68,12 +59,8 @@ router.post('/login', loginUser);
  *  Auth: Bearer token
  * @response
  *    {
- *      "userID": string,
+ *      "id": string,
  *      "email": string,
- *      "gptAPIKey": string,
- *      "firstName": string,
- *      "lastName": string,
- *      "profileImage": string,
  *    }
  */
 router.get('/me', protect, getMe);


### PR DESCRIPTION
A lot of shit in this PR:
* I changed our Router configuration to be better practice
   * Landing page is `/`, pages with no Nav bar don't need a parent element
   * All other pages requiring login are children of `/app` route
* Added a `ToastContextProvider`, by using `const openToast = useContext(ToastContext)`, you can pop open a [Snackbar](https://mui.com/material-ui/react-snackbar/)
* Some refactoring on `NavBar` for redirect and logout behavior
* Fixed styling for `AdditionalProfileForm` + `BasicProfileForm` that were broken, restyled `SignupStats` as part of that to be more responsive
* Created two form wrappers `PaperForm` and `Form`, for whether you want the [Paper](https://mui.com/material-ui/react-paper/) look
* ***JWT Authentication***
   * You MUST setup mongoDB after this PR is merged
   * Users are automatically redirected to `/login` if not logged in
   * `Auth.js` and `AuthService.js` contain reducers, thunks, and services that integrate with backend
   * Signing up will create a user (only the first step of signup page)
   * you can log out
   * BE is also integrated with MongoDB, associated changes to controller and middleware too.

https://github.com/d-x-s/airon-fitness/assets/67628346/60a5e1c8-be7a-4abf-a50e-f2f9e88daeaf


